### PR TITLE
Small fixes

### DIFF
--- a/bugzilla.py
+++ b/bugzilla.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import utils
 
 

--- a/crash_similarity.py
+++ b/crash_similarity.py
@@ -8,7 +8,7 @@ import multiprocessing
 import os
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import gensim
 import numpy as np
@@ -21,18 +21,15 @@ import utils
 pyximport.install()
 
 
-# Checks if the model has been trained in the last 24 hours
-def check_training_time():
-    with open('last_trained.txt', 'r') as myfile:
-        data = myfile.read()
-        last_trained_time = datetime.strptime(data, '%b %d %Y %I:%M%p').day
-
-    return datetime.today().day - last_trained_time < 1
+def retrain_timeout_expired(training_interval=timedelta(hours=24)):
+    with open('last_trained.txt', 'r') as f:
+        last_trained_time = datetime.strptime(f.read(), '%b %d %Y %H:%M')
+        return last_trained_time + training_interval < datetime.now()
 
 
-def store_training_time():
-    with open("last_trained.txt", "w") as text_file:
-        text_file.write(datetime.today().strftime('%b %d %Y %I:%M%p'))
+def save_training_time():
+    with open("last_trained.txt", "w") as f:
+        f.write(datetime.now().strftime('%b %d %Y %H:%M'))
 
 
 def clean_func(func):

--- a/crash_similarity.py
+++ b/crash_similarity.py
@@ -8,7 +8,6 @@ import multiprocessing
 import os
 import random
 import time
-from datetime import datetime, timedelta
 
 import gensim
 import numpy as np
@@ -20,17 +19,6 @@ import utils
 from download_data import download_stack_traces_for_signature
 
 pyximport.install()
-
-
-def retrain_timeout_expired(training_interval=timedelta(hours=24)):
-    with open('last_trained.txt', 'r') as f:
-        last_trained_time = datetime.strptime(f.read(), '%b %d %Y %H:%M')
-        return last_trained_time + training_interval < datetime.now()
-
-
-def save_training_time():
-    with open("last_trained.txt", "w") as f:
-        f.write(datetime.now().strftime('%b %d %Y %H:%M'))
 
 
 def clean_func(func):

--- a/crash_similarity.py
+++ b/crash_similarity.py
@@ -12,11 +12,12 @@ from datetime import datetime, timedelta
 
 import gensim
 import numpy as np
-from pyemd import emd
 import pyximport
+from pyemd import emd
 
 import download_data
 import utils
+from download_data import download_stack_traces_for_signature
 
 pyximport.install()
 
@@ -69,32 +70,9 @@ def read_corpus(fnames):
     return [gensim.models.doc2vec.TaggedDocument(trace, [i, signature]) for i, (trace, signature) in enumerate(elems)]
 
 
-def get_stack_trace_from_crashid(crash_id):
-    url = 'https://crash-stats.mozilla.com/api/ProcessedCrash'
-    params = {
-        'crash_id': crash_id
-    }
-    res = utils.get_with_retries(url, params)
-    return res.json()['proto_signature']
-
-
 def get_stack_traces_for_signature(fnames, signature, traces_num=100):
-    traces = set()
+    traces = download_stack_traces_for_signature(signature, traces_num)
 
-    # query stack traces online
-    url = 'https://crash-stats.mozilla.com/api/SuperSearch'
-    params = {
-        'signature': '=' + signature,
-        '_facets': ['proto_signature'],
-        '_facets_size': traces_num,
-        '_results_number': 0
-    }
-    res = utils.get_with_retries(url, params)
-    records = res.json()['facets']['proto_signature']
-    for record in records:
-        traces.add(record['term'])
-
-    # query stack traces from downloaded data
     for line in utils.read_files(fnames):
         data = json.loads(line)
         if data['signature'] == signature:

--- a/download_data.py
+++ b/download_data.py
@@ -131,3 +131,30 @@ def get_paths(days, product='Firefox'):
         last_day -= timedelta(1)
 
     return [get_path(last_day - timedelta(i), product) for i in range(0, days)]
+
+
+def download_stack_trace_for_crashid(crash_id):
+    url = 'https://crash-stats.mozilla.com/api/ProcessedCrash'
+    params = {
+        'crash_id': crash_id
+    }
+    res = utils.get_with_retries(url, params)
+    return res.json()['proto_signature']
+
+
+def download_stack_traces_for_signature(signature, traces_num=100):
+    url = 'https://crash-stats.mozilla.com/api/SuperSearch'
+    params = {
+        'signature': '=' + signature,
+        '_facets': ['proto_signature'],
+        '_facets_size': traces_num,
+        '_results_number': 0
+    }
+    res = utils.get_with_retries(url, params)
+    records = res.json()['facets']['proto_signature']
+
+    traces = set()
+    for record in records:
+        traces.add(record['term'])
+
+    return traces

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyemd==0.4.3
 gensim==1.0.1
-smart_open==1.4.0
+smart_open==1.5.1
 numpy==1.11.2
 requests[security]==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyemd==0.4.3
 gensim==1.0.1
 smart_open==1.4.0
 numpy==1.11.2

--- a/top_similar_traces.py
+++ b/top_similar_traces.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     model = crash_similarity.train_model(corpus)
 
     # gets the stack_trace corresponding to the crash_id (input by the user as an argument)
-    stack_trace = crash_similarity.get_stack_trace_from_crashid(args.crash_id)
+    stack_trace = download_data.download_stack_trace_for_crashid(args.crash_id)
 
     # returns the top similar stack traces (number of stack traces returned = args.top)
     similarities = crash_similarity.top_similar_traces(model, corpus, stack_trace, args.top)

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from smart_open import smart_open
 import requests
@@ -12,6 +12,17 @@ from requests.packages.urllib3.util.retry import Retry
 
 def utc_today():
     return datetime.utcnow().date()
+
+
+def retrain_timeout_expired(training_interval=timedelta(hours=24)):
+    with open('last_trained.txt', 'r') as f:
+        last_trained_time = datetime.strptime(f.read(), '%b %d %Y %H:%M')
+        return last_trained_time + training_interval < datetime.now()
+
+
+def save_training_time():
+    with open("last_trained.txt", "w") as f:
+        f.write(datetime.now().strftime('%b %d %Y %H:%M'))
 
 
 def get_with_retries(url, params=None, headers=None):

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from datetime import datetime
 
 from smart_open import smart_open


### PR DESCRIPTION
Add license notes.
Make timeout check more beautiful and general.
`gensim 1.0.1` depend on `smart_open 1.5.1` so I update smart-open
move side code from `crash_similarity.py`