### PR TITLE
drop python2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
 install:
     - pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
In unit tests for https://github.com/marco-c/crashsimilarity/pull/72 `AttributeError: 'DownloaderTest' object has no attribute 'assertCountEqual'` occurred.

Issue: https://github.com/marco-c/crashsimilarity/issues/69

