### PR TITLE
New classes hierarchy

### DIFF
--- a/crashsimilarity/models/gensim_model_wrapper.py
+++ b/crashsimilarity/models/gensim_model_wrapper.py
@@ -50,6 +50,10 @@ class Doc2vecModelWrapper(object):
         return Doc2vecModelWrapper(corpus, None)
 
     @staticmethod
+    def load_or_retrain():
+        raise NotImplementedError
+
+    @staticmethod
     def delete_old_models(current_date, path, force_train):
         raise NotImplementedError
 

--- a/crashsimilarity/models/gensim_model_wrapper.py
+++ b/crashsimilarity/models/gensim_model_wrapper.py
@@ -1,0 +1,68 @@
+import os
+
+import gensim
+from gensim.models import doc2vec
+import logging
+
+import multiprocessing
+
+import time
+
+from crashsimilarity import utils
+from crashsimilarity.utils import StackTraceProcessor
+
+
+class Doc2vecModelWrapper(object):
+    _MODELS_DIR = 'trained_models/doc2vec'
+
+    def __init__(self, corpus, model):
+        self.corpus = corpus
+        self.model = model
+
+    def save_model(self, name):
+        if not self.model:
+            raise ValueError('nothing to save: model is empty')
+        self.model.save(Doc2vecModelWrapper._path(name))
+
+    def train_model(self, model_params=None):
+        if not self.corpus:
+            raise ValueError('corpus is empty')
+        logging.debug('corpus length: {}'.format(self.corpus))
+        if not model_params:
+            try:
+                workers = multiprocessing.cpu_count()
+            except:
+                workers = 2
+            model_params = {'size': 200, 'window': 10, 'iter': 10, 'workers': workers, 'min_count': 1}
+        self.model = doc2vec.Doc2Vec(**model_params)
+        self.model.build_vocab(self.corpus)
+        logging.debug('vocabulary size: {}'.format(len(self.model.wv.vocab)))
+        start_time = time.time()
+        logging.info('Training started...')
+        self.model.train(self.corpus)
+        logging.info('Model trained in {} seconds'.format(time.time() - start_time))
+        return self
+
+    @staticmethod
+    def read_corpus(file_names):
+        traces = StackTraceProcessor.process(utils.read_files(file_names), 10)
+        corpus = [doc2vec.TaggedDocument(trace, [i, signature]) for i, (trace, signature) in enumerate(traces)]
+        return Doc2vecModelWrapper(corpus, None)
+
+    @staticmethod
+    def delete_old_models(current_date, path, force_train):
+        raise NotImplementedError
+
+    @staticmethod
+    def _path(name):
+        return '{}/{}.pickle'.format(Doc2vecModelWrapper._MODELS_DIR, name)
+
+    @staticmethod
+    def load_model(name):
+        path = Doc2vecModelWrapper._path(name)
+        if not os.path.exists(path):
+            return None
+        try:
+            return gensim.models.Doc2Vec.load(path)
+        except:
+            return None

--- a/crashsimilarity/models/similarity/base.py
+++ b/crashsimilarity/models/similarity/base.py
@@ -1,0 +1,65 @@
+from abc import abstractmethod
+
+import numpy as np
+
+
+class Algorithm(object):
+    @abstractmethod
+    def top_similar_traces(self, stack_trace, corpus, top_n):
+        """Given a stack trace, search similar stack traces
+
+        :return: list of (corpus index, distance(lower is better))
+        :rtype: list[tuple[int, float]]
+        """
+        pass
+
+    @abstractmethod
+    def signatures_similarity(self, signature1, signature2):
+        """Evaluates the similarity between two given signatures (by evaluating the similarity between the stack
+        traces that are in those signatures)
+
+        :rtype: float
+        """
+        pass
+
+    @abstractmethod
+    def signature_coherence(self, signature):
+        """Evaluates the similarity between the stack traces in a given signature
+
+        :return: similarities matrix
+        """
+        pass
+
+
+class GenericSimilarity(Algorithm):
+    def __init__(self, distance_calculator):
+        """
+        Similarity between stack traces is calculated as `1 / distance`
+
+        :param distance_calculator: function that takes two stack traces and return distance between them
+        """
+
+        def similarity_calculator(a, b):
+            d = distance_calculator(a, b)
+            return 1 / d if d != 0 else np.inf
+
+        self.similarity = similarity_calculator
+
+    def top_similar_traces(self, stack_trace, corpus, top_n):
+        similarities = [(i, self.similarity(stack_trace, c)) for i, c in enumerate(corpus)]
+        similarities.sort(key=lambda x: x[0], reverse=True)
+        return similarities[:top_n]
+
+    def signatures_similarity(self, signature1, signature2):
+        means = []
+        for trace in signature1:
+            cur = [self.similarity(trace, other) for other in signature2]
+            means.append(np.mean(cur))  # TODO: not so stupid?
+        return np.mean(means)
+
+    def signature_coherence(self, signature):
+        coherence = np.zeros((len(signature), len(signature)))
+        for i in range(len(signature)):
+            for j in range(i, len(signature)):
+                coherence[i, j] = coherence[j, i] = self.similarity(signature[i], signature[j])
+        return coherence


### PR DESCRIPTION
I decide to re-implement classes hierarchy from https://github.com/marco-c/crashsimilarity/pull/66
The idea is to split logically separated parts of the system to achieve Single Responsibility Principle.
We have four parts: data corpus, doc2vec model, distance calculator and main class(interface) that will be used to answer similarity questions. 
So I created `Doc2vecModelWrapper` which should be used to train\save\load model and to decide should we use old one or train new version.
We have already have `StackTraceProcessor` which will prepare corpus for `Doc2vecModelWrapper`
`Algorithm` is just a main interface. All similarity algorithms should extends it, like `GenericSimilarity` do.
In my next PR i will add different distance calculation function. One of them will be separated from `Algorithm` and will be used by `GenericSimilarity`. Relaxed WMD and WMD itself will be used by `WMDSimilarity`, since we should precomputed distances for performance reasons.
After that I will remove class hierarchy built by @ibrahimsharaf.